### PR TITLE
Add support for multiple spreadsheet configuration formats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ __pycache__/
 # Distribution / packaging
 .Python
 env/
+.venv/
 build/
 develop-eggs/
 dist/

--- a/config.sample.json
+++ b/config.sample.json
@@ -1,3 +1,13 @@
 {
     "spreadsheet_id": "abcdefgh-hijklmn-opqrstuvwxyz123456789ABCDEF"
 }
+
+// or
+
+{
+    "files": [
+        {
+            "id": "abcdefgh-hijklmn-opqrstuvwxyz123456789ABCDEF"
+        }
+    ]
+}

--- a/target_gsheet.py
+++ b/target_gsheet.py
@@ -290,7 +290,13 @@ def main():
                               discoveryServiceUrl=discoveryUrl)
 
     # Get spreadsheet_id
-    spreadsheet = get_spreadsheet(service, config['spreadsheet_id'])
+    try:
+        spreadsheet_id = config['spreadsheet_id'] if 'spreadsheet_id' in config else config['files'][0]['id']
+    except Exception as e:
+        logger.error(f"Error getting spreadsheet_id: {e}")
+        logger.error(f"Either 'spreadsheet_id' or a list called 'files' with at least one element that contains the 'id' of the spreadsheet must be provided in the config")
+        raise e
+    spreadsheet = get_spreadsheet(service, spreadsheet_id)
 
     input = io.TextIOWrapper(sys.stdin.buffer, encoding='utf-8')
     state = None


### PR DESCRIPTION
- Update config.sample.json to show alternative configuration with 'files' list
- Modify target_gsheet.py to handle both 'spreadsheet_id' and 'files' config formats
- Add .venv/ to .gitignore for virtual environment support